### PR TITLE
build: Replace "Cake.GitHubReleases" addin with "Cake.GitHub" addin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/Cake.GitHub"]
+	path = deps/Cake.GitHub
+	url = https://github.com/cake-contrib/Cake.GitHub.git

--- a/Cake.DotNetLocalTools.Module.sln
+++ b/Cake.DotNetLocalTools.Module.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33110.190
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E453CA95-C36A-4BB5-B8B9-D8251468FE03}"
 EndProject
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Build", "build\Build.csproj
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{8C54811F-4DEA-4021-9EDF-BB579129B97C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cake.GitHub", "deps\Cake.GitHub\src\Cake.GitHub\Cake.GitHub.csproj", "{A90AB52E-04E0-456A-B941-913725BA3B4C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +37,8 @@ Global
 		{CFDD2A3C-6510-4786-A305-1E76704196E9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6A7C6286-9BE1-4CF8-BBF7-EB4DFAB48B87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A7C6286-9BE1-4CF8-BBF7-EB4DFAB48B87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A90AB52E-04E0-456A-B941-913725BA3B4C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A90AB52E-04E0-456A-B941-913725BA3B4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -43,6 +47,7 @@ Global
 		{7F15995D-F55C-4A4D-87BD-B08B67A99B6A} = {E453CA95-C36A-4BB5-B8B9-D8251468FE03}
 		{CFDD2A3C-6510-4786-A305-1E76704196E9} = {E453CA95-C36A-4BB5-B8B9-D8251468FE03}
 		{6A7C6286-9BE1-4CF8-BBF7-EB4DFAB48B87} = {8C54811F-4DEA-4021-9EDF-BB579129B97C}
+		{A90AB52E-04E0-456A-B941-913725BA3B4C} = {8C54811F-4DEA-4021-9EDF-BB579129B97C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {551F3808-5BE6-4CF4-A80E-489DCCD2C9BF}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This way, you can easily use the tools from Cake while still having the tools an
 ### Cake Script
 
 To use the module in a Cake script file, perform the following steps
-
+d
 1. Add the preprocessor directive to install the module
 
     ```cs
@@ -136,6 +136,9 @@ This is equivalent to installing each tool individually:
 
 
 ## Building from source
+
+
+**Note:** This repository uses git submodules, so please use `git clone --recursive` to also clone the submodules.
 
 Building the project from source requires the .NET 7 SDK (version 7.0.100 as specified in [global.json](./global.json)).
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,8 @@ jobs:
   steps:
   - checkout: self
     fetchDepth: 0
+    submodules: recursive
+    displayName: Checkout
   - task: PowerShell@2
     displayName: Cake Build
     inputs:

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -1,20 +1,25 @@
-<Project Sdk="Microsoft.NET.Sdk">
-    
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)\..\</RunWorkingDirectory>
   </PropertyGroup>
-    
+
   <ItemGroup>
     <None Include="..\azure-pipelines.yml" Link="azure-pipelines.yml" />
   </ItemGroup>
-    
+
   <ItemGroup>
     <PackageReference Include="Cake.BuildSystems.Module" Version="3.0.3" />
     <PackageReference Include="Cake.Frosting" Version="3.0.0" />
     <PackageReference Include="Cake.GitVersioning" Version="3.5.119" />
-    <PackageReference Include="Cake.GitHubReleases" Version="1.0.10" />
   </ItemGroup>
-    
+
+
+  <!-- Cake.GitHub (currently pulled in via git submodules instead of NuGet since not all featues in the repo have been released to NuGet yet) -->
+  <ItemGroup>
+    <ProjectReference Include="..\deps\Cake.GitHub\src\Cake.GitHub\Cake.GitHub.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/build/Tasks/CreateGitHubReleaseTask.cs
+++ b/build/Tasks/CreateGitHubReleaseTask.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Cake.Core.Diagnostics;
 using Cake.Frosting;
-using Cake.GitHubReleases;
+using Cake.GitHub;
 using Cake.GitVersioning;
 
 namespace Build.Tasks
@@ -50,7 +50,7 @@ namespace Build.Tasks
 
         private async Task CreateDraftRelease(BuildContext context, string accessToken, string version, string changeLog)
         {
-            var releaseSettings = new GitHubReleaseCreateSettings(context.GitHub.RepositoryOwner, context.GitHub.RepositoryName, "vNext")
+            var releaseSettings = new GitHubCreateReleaseSettings()
             {
                 Draft = true,
                 Prerelease = true,
@@ -58,26 +58,22 @@ namespace Build.Tasks
                 Body = changeLog,
                 Overwrite = true,
                 TargetCommitish = context.Git.CommitId,
-                HostName = context.GitHub.HostName,
-                AccessToken = accessToken
             };
 
-            await context.GitHubReleaseCreateAsync(releaseSettings);
+            await context.GitHubCreateReleaseAsync(null, accessToken, context.GitHub.RepositoryOwner, context.GitHub.RepositoryName, "vNext", releaseSettings);
         }
 
         private async Task CreateRelease(BuildContext context, string accessToken, string version, string changeLog)
         {
-            var releaseSettings = new GitHubReleaseCreateSettings(context.GitHub.RepositoryOwner, context.GitHub.RepositoryName, $"v{version}")
+            var releaseSettings = new GitHubCreateReleaseSettings()
             {
                 Name = $"v{version}",
                 Body = changeLog,
                 TargetCommitish = context.Git.CommitId,
-                AccessToken = accessToken,
-                HostName = context.GitHub.HostName,
                 Assets = context.Output.PackageFiles.ToList()
             };
 
-            await context.GitHubReleaseCreateAsync(releaseSettings);
+            await context.GitHubCreateReleaseAsync(null, accessToken, context.GitHub.RepositoryOwner, context.GitHub.RepositoryName, $"v{version}", releaseSettings);
         }
     }
 }

--- a/build/_Context/GitHubContext.cs
+++ b/build/_Context/GitHubContext.cs
@@ -10,9 +10,7 @@ namespace Build
         private readonly BuildContext m_Context;
         private readonly Lazy<GitHubProjectInfo> m_ProjectInfo;
 
-
-        public string HostName => m_ProjectInfo.Value.Host;
-
+       
         public string RepositoryOwner => m_ProjectInfo.Value.Owner;
 
         public string RepositoryName => m_ProjectInfo.Value.Repository;
@@ -29,7 +27,6 @@ namespace Build
         {
             string prefix = new String(' ', indentWidth);
 
-            m_Context.Log.Information($"{prefix}{nameof(HostName)}: {HostName}");
             m_Context.Log.Information($"{prefix}{nameof(RepositoryOwner)}: {RepositoryOwner}");
             m_Context.Log.Information($"{prefix}{nameof(RepositoryName)}: {RepositoryName}");
         }


### PR DESCRIPTION
The functionality of the "Cake.GitHubReleases" addin has been integrated into the "Cake.GitHub" addin.
However, the version of "Cake.GitHub" available on NuGet does not yet have this functionality, so it is referenced as git submodule instead.
