### PR TITLE
build: Collect code coverage when running tests

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -10,4 +10,5 @@ return new CakeHost()
             // Since this build is building the local tools module, the build cannot use it.
             // Instead install all the required tools individually
             .InstallTool(new Uri("dotnet:?package=Grynwald.ChangeLog&version=1.1.118"))
+            .InstallTool(new Uri("dotnet:?package=dotnet-reportgenerator-globaltool&version=5.1.12"))
             .Run(args);

--- a/build/_Context/BuildContext.cs
+++ b/build/_Context/BuildContext.cs
@@ -38,6 +38,8 @@ namespace Build
 
         public virtual CodeFormattingSettings CodeFormattingSettings { get; }
 
+        public virtual TestSettings TestSettings { get; }
+
 
         public BuildContext(ICakeContext context) : base(context)
         {
@@ -73,6 +75,7 @@ namespace Build
                     RootDirectory.Combine("deps")
                 }
             };
+            TestSettings = new(this);
         }
 
 
@@ -103,6 +106,9 @@ namespace Build
 
             Log.Information($"{prefix(indentWidth)}{nameof(CodeFormattingSettings)}:");
             CodeFormattingSettings.PrintToLog(indentWidth + 2);
+
+            Log.Information($"{prefix(indentWidth)}{nameof(TestSettings)}:");
+            TestSettings.PrintToLog(indentWidth + 2);
 
             // 
             Log.Information($"{nameof(PushTargets)}:");

--- a/build/_Context/OutputContext.cs
+++ b/build/_Context/OutputContext.cs
@@ -34,6 +34,11 @@ namespace Build
 
         public IEnumerable<FilePath> PackageFiles => m_Context.FileSystem.GetFilePaths(PackagesDirectory, "*.nupkg");
 
+        public DirectoryPath CodeCoverageReportDirectory => BinariesDirectory.Combine(m_Context.BuildSettings.Configuration).Combine("CodeCoverage").Combine("Report");
+
+        public DirectoryPath CodeCoverageHistoryDirectory => BinariesDirectory.Combine(m_Context.BuildSettings.Configuration).Combine("CodeCoverage").Combine("History");
+
+
 
         public OutputContext(BuildContext context)
         {

--- a/build/_Context/TestSettings.cs
+++ b/build/_Context/TestSettings.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Cake.Common;
+using Cake.Core.Diagnostics;
+
+namespace Build
+{
+    public class TestSettings
+    {
+        private readonly BuildContext m_Context;
+
+
+        public virtual bool CollectCodeCoverage => m_Context.Argument("collect-code-coverage", true);
+
+
+        public TestSettings(BuildContext context)
+        {
+            m_Context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+
+        public void PrintToLog(int indentWidth = 0)
+        {
+            string prefix = new String(' ', indentWidth);
+            m_Context.Log.Information($"{prefix}{nameof(CollectCodeCoverage)}: {CollectCodeCoverage}");
+        }
+    }
+}


### PR DESCRIPTION
Add collection of code coverage to "Test" task and generate a Code Coverage Reprot afterwards.
When running on Azure Pipelines, publish the code coverage report to the Azure Pipelnes Web UI.
